### PR TITLE
fix: add suggestion list for images

### DIFF
--- a/hack/provider/provider.yaml
+++ b/hack/provider/provider.yaml
@@ -51,6 +51,23 @@ options:
   DISK_IMAGE:
     description: The disk image to use.
     default: docker-20-04
+    suggestions:
+      - docker-20-04
+      - almalinux-8-x64
+      - almalinux-9-x64
+      - centos-7-x64
+      - centos-stream-9-x64
+      - centos-stream-8-x64
+      - debian-10-x64
+      - debian-12-x64
+      - debian-11-x64
+      - fedora-37-x64
+      - fedora-38-x64
+      - rockylinux-8-x64
+      - rockylinux-9-x64
+      - ubuntu-20-04-x64
+      - ubuntu-22-04-x64
+      - ubuntu-23-04-x64
   MACHINE_TYPE:
     description: The machine type to use.
     default: s-4vcpu-8gb


### PR DESCRIPTION
Add a proper suggestion list for droplet images
Default to the docker droplet, but make it clearer that other options are possible

![image](https://github.com/loft-sh/devpod-provider-digitalocean/assets/598882/91b9fda8-5ec9-4dfa-b7f2-c6a40e441ec9)

Fix #2 
Resolves ENG-1741

