### PR TITLE
allow end user to configure REGION on the command line

### DIFF
--- a/hack/provider/provider.yaml
+++ b/hack/provider/provider.yaml
@@ -8,6 +8,7 @@ optionGroups:
       - DISK_SIZE
       - DISK_IMAGE
       - MACHINE_TYPE
+      - REGION
     name: "Digital Ocean options"
   - options:
       - AGENT_PATH


### PR DESCRIPTION
Unless I am misunderstanding, it does not appear that `devpod` lets a user configure the REGION over the CLI, only in the UI.

Running:

```bash
devpod provider add digitalocean --name test -o REGION=nyc1 -o DISK_IMAGE=ubuntu-24-04-x64 -o DISK_SIZE=30 -o MACHINE_TYPE=s-2vcpu-4gb
```

results in everything else being configured correctly, except the region gets configured as the default `fra1`. I am not sure this is the correct change to fix that, but based on how the other variables show up here I figured I'd raise it this way.